### PR TITLE
Fix dead link in dynamo troubleshooting page #103276

### DIFF
--- a/docs/2.0/dynamo/troubleshooting.html
+++ b/docs/2.0/dynamo/troubleshooting.html
@@ -1083,7 +1083,7 @@ to detect bugs in our codegen or with a backend compiler.</p>
 <p>If you experience problems with TorchDynamo, <a class="reference external" href="https://github.com/pytorch/torchdynamo/issues">file a GitHub
 issue</a>.</p>
 <p>Before filing an issue, read over the <a class="reference external" href="../README.md">README</a>,
-<a class="reference external" href="./TROUBLESHOOTING.md">TROUBLESHOOTING</a>, and search for similar
+<a class="reference external" href="../_sources/dynamo/troubleshooting.rst.txt">TROUBLESHOOTING</a>, and search for similar
 issues.</p>
 <p>When filing an issue, include the information about your
 OS, Python&lt; PyTorch, CUDA, and Triton versions info by running:</p>


### PR DESCRIPTION
Fixes pytorch/pytorch#103276

The issue reported a dead link in the `docs/2.0/dynamo/troubleshooting.html` file. The previous link was pointing to a non-existent `TROUBLESHOOTING.md` file.

In this pull request, I have updated the link to correctly point to `../_sources/dynamo/troubleshooting.rst.txt`, resolving the dead link issue. The modified file is included in this PR.

@ezyang